### PR TITLE
Change probability to mean mute probability

### DIFF
--- a/NoodleBox/source/sequence.h
+++ b/NoodleBox/source/sequence.h
@@ -291,7 +291,7 @@ public:
 
 			byte layer_update[NUM_LAYERS] = {0}; 			// whether individual layer has updated
 			int any_layer_updated = 0;						// whether any layer has updated
-			int dice_roll = 1+rand()%16;		 			// random value for gate probability
+			int dice_roll = rand()%16;		 			// random value for gate probability
 			clock::TICKS_TYPE ticks = g_clock.get_ticks(); 	// get the current clock tick count
 			for(int i=0; i<NUM_LAYERS; ++i) {
 				int update;

--- a/NoodleBox/source/sequence_layer.h
+++ b/NoodleBox/source/sequence_layer.h
@@ -1004,15 +1004,13 @@ public:
 			}
 
 			m_state.m_step_timeout = g_clock.get_ms_per_measure(m_cfg.m_step_rate);
-			//m_state.m_suppress_step = 0;
-			if(step_value.get_prob()) { // nonzero probability?
-				if(dice_roll>step_value.get_prob()) {
-					// dice roll is between 1 and 16, if this number is greater
-					// than the step probability (1-15) then the step will
-					// be suppressed
-					step_value.clear(CSequenceStep::ALL_DATA);
-					step_value.set(CSequenceStep::IGNORE_POINT,1);
-				}
+
+			// apply mute probability. dice roll is between 0 and 15.
+			// if this number is less than the step probability (0-15)
+			// then the step will be suppressed.
+			if(dice_roll < step_value.get_prob()) {
+				step_value.clear(CSequenceStep::ALL_DATA);
+				step_value.set(CSequenceStep::IGNORE_POINT,1);
 			}
 
 			// after we play a step, we need to schedule the next one...


### PR DESCRIPTION
This changes step probability to be more of a continuous setting, like retrig.

Under the previous definition of step probability, setting it to zero meant 'always play', but increasing the value to one immediately jumped to the lowest actual probability of playing the step.

With this change, the definition is inverted and now means 'mute probability'. Zero still means the step will always play. Increasing the value makes triggering the gate less likely. The rationale for this is that it allows dialing in the value in a more natural way.